### PR TITLE
Switch to split repositories for rmf_core

### DIFF
--- a/rmf.repos
+++ b/rmf.repos
@@ -3,13 +3,13 @@ repositories:
     type: git
     url: https://github.com/open-rmf/rmf_battery.git
     version: main
-  rmf/rmf_core_msgs:
+  rmf/rmf_internal_msgs:
     type: git
-    url: https://github.com/open-rmf/rmf_core_msgs.git
+    url: https://github.com/open-rmf/rmf_internal_msgs.git
     version: main
-  rmf/rmf_core_ros2:
+  rmf/rmf_ros2:
     type: git
-    url: https://github.com/open-rmf/rmf_core_ros2.git
+    url: https://github.com/open-rmf/rmf_ros2.git
     version: main
   rmf/rmf_task:
     type: git

--- a/rmf.repos
+++ b/rmf.repos
@@ -2,27 +2,27 @@ repositories:
   rmf/rmf_battery:
     type: git
     url: https://github.com/open-rmf/rmf_battery.git
-    version: master
+    version: main
   rmf/rmf_core_msgs:
     type: git
     url: https://github.com/open-rmf/rmf_core_msgs.git
-    version: master
+    version: main
   rmf/rmf_core_ros2:
     type: git
     url: https://github.com/open-rmf/rmf_core_ros2.git
-    version: master
+    version: main
   rmf/rmf_task:
     type: git
     url: https://github.com/open-rmf/rmf_task.git
-    version: master
+    version: main
   rmf/rmf_traffic:
     type: git
     url: https://github.com/open-rmf/rmf_traffic.git
-    version: master
+    version: main
   rmf/rmf_utils:
     type: git
     url: https://github.com/open-rmf/rmf_utils.git
-    version: master
+    version: main
   rmf/rmf_schedule_visualizer:
     type: git
     url: https://github.com/osrf/rmf_schedule_visualizer.git

--- a/rmf.repos
+++ b/rmf.repos
@@ -1,7 +1,27 @@
 repositories:
-  rmf/rmf_core:
+  rmf/rmf_battery:
     type: git
-    url: https://github.com/osrf/rmf_core.git
+    url: https://github.com/open-rmf/rmf_battery.git
+    version: master
+  rmf/rmf_core_msgs:
+    type: git
+    url: https://github.com/open-rmf/rmf_core_msgs.git
+    version: master
+  rmf/rmf_core_ros2:
+    type: git
+    url: https://github.com/open-rmf/rmf_core_ros2.git
+    version: master
+  rmf/rmf_task:
+    type: git
+    url: https://github.com/open-rmf/rmf_task.git
+    version: master
+  rmf/rmf_traffic:
+    type: git
+    url: https://github.com/open-rmf/rmf_traffic.git
+    version: master
+  rmf/rmf_utils:
+    type: git
+    url: https://github.com/open-rmf/rmf_utils.git
     version: master
   rmf/rmf_schedule_visualizer:
     type: git

--- a/rmf.repos
+++ b/rmf.repos
@@ -23,6 +23,14 @@ repositories:
     type: git
     url: https://github.com/open-rmf/rmf_utils.git
     version: main
+  rmf/rmf_cmake_uncrustify:
+    type: git
+    url: https://github.com/open-rmf/rmf_cmake_uncrustify.git
+    version: main
+  rmf/ament_cmake_catch2:
+    type: git
+    url: https://github.com/open-rmf/ament_cmake_catch2.git
+    version: main
   rmf/rmf_schedule_visualizer:
     type: git
     url: https://github.com/osrf/rmf_schedule_visualizer.git


### PR DESCRIPTION
This PR switches the `rmf.repos` file to use the new repositories created by splitting up `osrf/rmf_core`.