### PR TITLE
Align traffic editor repo with others

### DIFF
--- a/rmf.repos
+++ b/rmf.repos
@@ -51,7 +51,7 @@ repositories:
     type: git
     url: https://github.com/open-rmf/rmf_simulation.git
     version: main
-  traffic_editor/rmf_traffic_editor:
+  rmf/rmf_traffic_editor:
     type: git
     url: https://github.com/open-rmf/rmf_traffic_editor.git
     version: master

--- a/rmf.repos
+++ b/rmf.repos
@@ -54,7 +54,7 @@ repositories:
   rmf/rmf_traffic_editor:
     type: git
     url: https://github.com/open-rmf/rmf_traffic_editor.git
-    version: master
+    version: main
   demonstrations/rmf_demos:
     type: git
     url: https://github.com/open-rmf/rmf_demos.git


### PR DESCRIPTION
Currently the `rmf_traffic_editor` repo is in its own subdirectory when running `vcs import` on the `rmf.repos` file. This PR aligns it next to the other `rmf` repositories.

Also reflects the change in default branch name.

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>