### PR TITLE
Fix/docker ci

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,6 @@ jobs:
   build-docker-images:
     name: Push Docker image to GitHub Packages
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
       - name: build rmf image and push to gh registry
@@ -18,4 +17,5 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: docker.pkg.github.com
           repository: ${{ github.repository }}/rmf_demos
+          push: ${{ github.event_name == 'push' }} # update registry only during push to main
           tags: latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,12 +1,14 @@
-name: Docker Image CI
-
+name: build
 on:
   push:
-    branches: [ main ]  
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 jobs:
   build-docker-images:
     name: Push Docker image to GitHub Packages
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v2
       - name: build rmf image and push to gh registry
@@ -17,4 +19,3 @@ jobs:
           registry: docker.pkg.github.com
           repository: ${{ github.repository }}/rmf_demos
           tags: latest
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,10 @@ RUN mkdir $HOME/rmf_demos_ws
 WORKDIR $HOME/rmf_demos_ws
 RUN mkdir src
 RUN rosdep update --rosdistro $ROS_DISTRO
-RUN wget https://raw.githubusercontent.com/open-rmf/rmf/main/rmf.repos \
-    && vcs import src < rmf.repos \
+
+# This replaces: wget https://raw.githubusercontent.com/open-rmf/rmf/main/rmf.repos
+COPY rmf.repos rmf.repos
+RUN vcs import src < rmf.repos \
     && apt-get update \
     && apt-get upgrade -y \
     && rosdep update \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RMF
 
-![](https://github.com/open-rmf/rmf/workflows/main/badge.svg)
+![](https://github.com/open-rmf/rmf/workflows/build/badge.svg)
 
 The OpenRMF platform for multi-fleet robot management.
 
@@ -68,6 +68,7 @@ colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release
 
 > NOTE: The first time the build occurs, many simulation models will be downloaded from Ignition Fuel to populate the scene when the simulation is run.
 As a result, the first build can take a very long time depending on the server load and your Internet connection (for example, 60 minutes).
+
 > The models required for each of the demo worlds will be automatically downloaded into `~/.gazebo/models` from Ignition Fuel when building the package `rmf_demo_maps`. If you notice something wrong with the models in the simulation, your `~/.gazebo/models` path might contain deprecated models not from Fuel. An easy way to solve this is to remove all models except for `sun` and `ground_plane` from `~/.gazebo/model`s, and perform a clean rebuild of the package `rmf_demo_maps`.
 
 ## Run RMF Demos


### PR DESCRIPTION
CI related

- Previous implementation of `wget` the latest `rmf.repos.` from `main` is incorrect. Should use the current `rmf.repos` from the working branch.
  - This will be handy in future to run a CI test with different rmf working branches, by re-configure `rmf.repos`. (then manually trigger a build process, or have a webhook soon{?})
- Fix badge
- Trigger build during PR, while not update the docker pkg