### PR TITLE
Migrate github to use SSH keys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update \
     wget \
     python3-pip \
   && pip3 install flask-socketio \
+  && pip3 install vcstool \
   && rm -rf /var/lib/apt/lists/*
 
 # setup keys

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ RUN apt-get update \
     qt5-default \
     wget \
     python3-pip \
+    ssh-client \
   && pip3 install flask-socketio \
-  && pip3 install vcstool \
   && rm -rf /var/lib/apt/lists/*
 
 # setup keys

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # add github as a known ssh host
-RUN ssh-keyscan github.com >> ~/.ssh/known_hosts
+RUN  mkdir /root/.ssh && chmod 0700 /root/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
 
 # setup keys
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ RUN apt-get update \
   && pip3 install flask-socketio \
   && rm -rf /var/lib/apt/lists/*
 
+# add github as a known ssh host
+RUN ssh-keyscan github.com >> ~/.ssh/known_hosts
+
 # setup keys
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
 

--- a/rmf.repos
+++ b/rmf.repos
@@ -1,65 +1,65 @@
 repositories:
   rmf/rmf_battery:
     type: git
-    url: https://github.com/open-rmf/rmf_battery.git
+    url: git@github.com:open-rmf/rmf_battery.git
     version: main
   rmf/rmf_internal_msgs:
     type: git
-    url: https://github.com/open-rmf/rmf_internal_msgs.git
+    url: git@github.com:open-rmf/rmf_internal_msgs.git
     version: main
   rmf/rmf_ros2:
     type: git
-    url: https://github.com/open-rmf/rmf_ros2.git
+    url: git@github.com:open-rmf/rmf_ros2.git
     version: main
   rmf/rmf_task:
     type: git
-    url: https://github.com/open-rmf/rmf_task.git
+    url: git@github.com:open-rmf/rmf_task.git
     version: main
   rmf/rmf_traffic:
     type: git
-    url: https://github.com/open-rmf/rmf_traffic.git
+    url: git@github.com:open-rmf/rmf_traffic.git
     version: main
   rmf/rmf_utils:
     type: git
-    url: https://github.com/open-rmf/rmf_utils.git
+    url: git@github.com:open-rmf/rmf_utils.git
     version: main
   rmf/rmf_cmake_uncrustify:
     type: git
-    url: https://github.com/open-rmf/rmf_cmake_uncrustify.git
+    url: git@github.com:open-rmf/rmf_cmake_uncrustify.git
     version: main
   rmf/ament_cmake_catch2:
     type: git
-    url: https://github.com/open-rmf/ament_cmake_catch2.git
+    url: git@github.com:open-rmf/ament_cmake_catch2.git
     version: main
   rmf/rmf_visualization:
     type: git
-    url: https://github.com/open-rmf/rmf_visualization.git
+    url: git@github.com:open-rmf/rmf_visualization.git
     version: main
   rmf/rmf_visualization_msgs:
     type: git
-    url: https://github.com/open-rmf/rmf_visualization_msgs.git
+    url: git@github.com:open-rmf/rmf_visualization_msgs.git
     version: main
   rmf/rmf_building_map_msgs:
     type: git
-    url: https://github.com/open-rmf/rmf_building_map_msgs.git
+    url: git@github.com:open-rmf/rmf_building_map_msgs.git
     version: main
   rmf/rmf_simulation:
     type: git
-    url: https://github.com/open-rmf/rmf_simulation.git
+    url: git@github.com:open-rmf/rmf_simulation.git
     version: main
   rmf/rmf_traffic_editor:
     type: git
-    url: https://github.com/open-rmf/rmf_traffic_editor.git
+    url: git@github.com:open-rmf/rmf_traffic_editor.git
     version: main
   demonstrations/rmf_demos:
     type: git
-    url: https://github.com/open-rmf/rmf_demos.git
+    url: git@github.com:open-rmf/rmf_demos.git
     version: main
   thirdparty/ros_ign:
     type: git
-    url: https://github.com/osrf/ros_ign.git
+    url: git@github.com:osrf/ros_ign.git
     version: dashing
   thirdparty/menge_vendor:
     type: git
-    url: https://github.com/open-rmf/menge_vendor.git
+    url: git@github.com:open-rmf/menge_vendor.git
     version: master


### PR DESCRIPTION
## Bug fix

### Fixed bug
This is a quality of life improvement. The old file uses `https`. However, now every time I clone a new workspace I need to manually switch to ssh before I push otherwise GitHub sends me angry emails with a depreciation notice. For more info see: https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/

### Fix applied
The fix is simply changing the urls to use ssh instead.
