### PR TITLE
Update ros_ign branch to Foxy

### DIFF
--- a/rmf.repos
+++ b/rmf.repos
@@ -58,7 +58,7 @@ repositories:
   thirdparty/ros_ign:
     type: git
     url: https://github.com/osrf/ros_ign.git
-    version: dashing
+    version: foxy
   thirdparty/menge_vendor:
     type: git
     url: https://github.com/open-rmf/menge_vendor.git

--- a/rmf.repos
+++ b/rmf.repos
@@ -55,10 +55,6 @@ repositories:
     type: git
     url: https://github.com/open-rmf/rmf_demos.git
     version: main
-  thirdparty/ros_ign:
-    type: git
-    url: https://github.com/osrf/ros_ign.git
-    version: foxy
   thirdparty/menge_vendor:
     type: git
     url: https://github.com/open-rmf/menge_vendor.git


### PR DESCRIPTION
## New feature implementation

### Implemented feature

Updating ros_ign branch from dashing to foxy.

### Implementation description

The dashing branch might have resulted in undefined behavior since it compiled [against citadel](https://github.com/ignitionrobotics/ros_ign/blob/dashing/ros_ign_bridge/package.xml#L22-L27). The Foxy branch _can_ [compile against the edifice libraries](https://github.com/ignitionrobotics/ros_ign/blob/foxy/ros_ign_bridge/package.xml#L25-L27), provided the `IGNITION_VERSON` variable is exported, which is still TODO.
Still, even with this issue pending the foxy branch is more up to date than dashing so an upgrade is a probably a good idea.