### PR TITLE
Remove ros_ign source repo

### DIFF
--- a/rmf.repos
+++ b/rmf.repos
@@ -58,7 +58,7 @@ repositories:
   thirdparty/ros_ign:
     type: git
     url: https://github.com/osrf/ros_ign.git
-    version: dashing
+    version: foxy
   thirdparty/menge_vendor:
     type: git
     url: https://github.com/open-rmf/menge_vendor.git

--- a/rmf.repos
+++ b/rmf.repos
@@ -55,10 +55,6 @@ repositories:
     type: git
     url: https://github.com/open-rmf/rmf_demos.git
     version: main
-  thirdparty/ros_ign:
-    type: git
-    url: https://github.com/osrf/ros_ign.git
-    version: foxy
   thirdparty/menge_vendor:
     type: git
     url: https://github.com/open-rmf/menge_vendor.git


### PR DESCRIPTION
## New feature implementation

### Implemented feature

Remove `ros_ign` and use the binary package instead, depends on [rmf_demos #60](https://github.com/open-rmf/rmf_demos/pull/60) which should be merged first.

### Implementation description

Since `ros_ign` related packages are now available as binaries, we can avoid building them from source, saving some time and effort when updating distributions, as well as building time and size of the RMF workspace.