### PR TITLE
Updating docs to galactic / remove outdated notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 The OpenRMF platform for multi-fleet robot management.
 
 ---
-## Install ROS 2 Foxy
+## Install ROS 2 Galactic
 
-First, please follow the installation instructions for ROS 2 Foxy.
-If you are on an Ubuntu 20.04 LTS machine (as recommended), [here is the binary install page for ROS 2 Foxy on Ubuntu 20.04](https://index.ros.org/doc/ros2/Installation/Foxy/Linux-Install-Debians/)
+First, please follow the installation instructions for ROS 2 Galactic.
+If you are on an Ubuntu 20.04 LTS machine (as recommended), [here is the binary install page for ROS 2 Galactic on Ubuntu 20.04](https://docs.ros.org/en/galactic/Installation/Ubuntu-Install-Debians.html)
 
 ## Install rosdep
 `rosdep` helps install dependencies for ROS packages across various distros. It can be installed with:
@@ -36,7 +36,6 @@ Install all non-ROS dependencies of RMF packages,
 sudo apt update && sudo apt install \
   git cmake python3-vcstool curl \
   qt5-default \
-  ignition-edifice \
   -y
 python3 -m pip install flask-socketio
 sudo apt-get install python3-colcon*
@@ -55,7 +54,7 @@ vcs import src < rmf.repos
 Ensure all ROS 2 prerequisites are fulfilled,
 ```
 cd ~/rmf_ws
-rosdep install --from-paths src --ignore-src --rosdistro foxy -yr
+rosdep install --from-paths src --ignore-src --rosdistro galactic -yr
 ```
 
 ## Compiling Instructions
@@ -64,14 +63,12 @@ On `Ubuntu 20.04`:
 
 ```bash
 cd ~/rmf_ws
-source /opt/ros/foxy/setup.bash
+source /opt/ros/galactic/setup.bash
 colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release
 ```
 
 > NOTE: The first time the build occurs, many simulation models will be downloaded from Ignition Fuel to populate the scene when the simulation is run.
 As a result, the first build can take a very long time depending on the server load and your Internet connection (for example, 60 minutes).
-
-> The models required for each of the demo worlds will be automatically downloaded into `~/.gazebo/models` from Ignition Fuel when building the package `rmf_demo_maps`. If you notice something wrong with the models in the simulation, your `~/.gazebo/models` path might contain deprecated models not from Fuel. An easy way to solve this is to remove all models except for `sun` and `ground_plane` from `~/.gazebo/model`s, and perform a clean rebuild of the package `rmf_demo_maps`.
 
 ## Run RMF Demos
 
@@ -80,7 +77,7 @@ Demonstrations of RMF is shown in [rmf_demos](https://github.com/open-rmf/rmf_de
 ### Docker Containers
 Alternatively, you can run RMF Demos by using [docker](https://docs.docker.com/engine/install/ubuntu/).
 
-Pull docker image from `opern-rm/rmf` github registry (setup refer [here](https://docs.github.com/en/free-pro-team@latest/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages#authenticating-with-a-personal-access-token)).
+Pull docker image from `open-rmf/rmf` github registry (setup refer [here](https://docs.github.com/en/free-pro-team@latest/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages#authenticating-with-a-personal-access-token)).
 ```bash
 docker pull docker.pkg.github.com/open-rmf/rmf/rmf_demos:latest
 docker tag docker.pkg.github.com/open-rmf/rmf/rmf_demos:latest rmf:latest
@@ -96,7 +93,7 @@ This will run `rmf_demos` in headless mode. Open `localhost:5000` with a browser
 
 ## Roadmap
 
-A near-term roadmap of the entire RMF project (including and beyond `rmf_core`) can be found in the user manual [here](https://osrf.github.io/ros2multirobotbook/roadmap.html).
+A near-term roadmap of the entire RMF project (including and beyond `rmf_traffic`) can be found in the user manual [here](https://osrf.github.io/ros2multirobotbook/roadmap.html).
 
 ## Integrating with RMF
 


### PR DESCRIPTION
Since we are now using Galactic update the notes to include it.
Also remove outdated instructions, namely:

- Installing `ignition-edifice` manually (is now done through `rosdep`)
- Models in `.gazebo/models` (they are now in the `install` folder)

A bunch of minor fixes as well (i.e. `rmf_core` -> `rmf_traffic`)