### PR TITLE
Remove rmf_cmake_uncrustify

### DIFF
--- a/rmf.repos
+++ b/rmf.repos
@@ -23,10 +23,6 @@ repositories:
     type: git
     url: https://github.com/open-rmf/rmf_utils.git
     version: main
-  rmf/rmf_cmake_uncrustify:
-    type: git
-    url: https://github.com/open-rmf/rmf_cmake_uncrustify.git
-    version: main
   rmf/ament_cmake_catch2:
     type: git
     url: https://github.com/open-rmf/ament_cmake_catch2.git


### PR DESCRIPTION
We currently have the rmf_cmake_uncrustify package that is used for style checking with colcon test. The original reason for having this package and not using ament_cmake_uncrustify was that the latter did not support custom uncrustify configuration files. But this feature was [merged upstream](https://github.com/ament/ament_lint/pull/200) quite a while ago and has been part of `foxy` and `galactic` releases. Hence, switching back to `ament_cmake_uncrustify` for ease of maintenance and distribution.