### PR TITLE
install instructions: don't pass rosdep the ignore-errors flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ vcs import src < rmf.repos
 Ensure all ROS 2 prerequisites are fulfilled,
 ```
 cd ~/rmf_ws
-rosdep install --from-paths src --ignore-src --rosdistro galactic -yr
+rosdep install --from-paths src --ignore-src --rosdistro galactic -y
 ```
 
 ### Compiling Instructions


### PR DESCRIPTION
In the installation instructions, currently we suggest to use the `-r` flag during `rosdep install`, which tells `rosdep` to ignore errors. Unfortunately due to the amount of console output produced, it's basically impossible to note things like missing rosdep keys or other errors. This PR just removes the `-r` flag from the installation instructions, which will cause `rosdep` to halt when it sees an error, so that it's easier to track it down during dependency-installation, rather than at compilation time or run time.

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>