### PR TITLE
add demo fleet adapter build instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
     qt5-default \
     wget \
     python3-pip \
-  && pip3 install flask-socketio \
+  && pip3 install flask-socketio fastapi uvicorn \
   && rm -rf /var/lib/apt/lists/*
 
 # setup keys

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ sudo apt update && sudo apt install \
   git cmake python3-vcstool curl \
   qt5-default \
   -y
-python3 -m pip install flask-socketio
+python3 -m pip install flask-socketio fastapi uvicorn
 sudo apt-get install python3-colcon*
 ```
 


### PR DESCRIPTION
This PR updates the build instructions to support the demo fleet adapter integration by installing `fastapi` and `uvicorn` according to open-rmf/rmf_demos#109