### PR TITLE
Add ros_ign to be built from source

### DIFF
--- a/rmf.repos
+++ b/rmf.repos
@@ -67,3 +67,7 @@ repositories:
     type: git
     url: https://github.com/open-rmf/pybind11_json_vendor.git
     version: main
+  thirdparty/ros_ign:
+    type: git
+    url: https://github.com/ignitionrobotics/ros_ign.git
+    version: ros2


### PR DESCRIPTION
## New feature implementation

### Implemented feature

:warning: **[TEMPORARY WORKAROND]** :warning:  As we are releasing in Jammy and transitioning to Ignition Fortress, binaries of ros_ign for users under galactic will not work.
This PR temporarily adds `ros_ign` back to the `rmf.repos` file, to be removed when Humble binaries are released and the transition is completed.
Should be merged together with the `rmf_simulation` PR to migrate to Fortress https://github.com/open-rmf/rmf_simulation/pull/70

### Implementation description

The `ros_ign_bridge` in the ros2 branch has a [logic in CMakeLists](https://github.com/ignitionrobotics/ros_ign/blob/ros2/ros_ign_bridge/CMakeLists.txt#L25-L43) to build under edifice if an environment variable was set or under fortress by default. The environment variable is not normally set so it will build with Fortress support.