### PR TITLE
Remove building ros_ign from source since 0.233.4 has been released

### DIFF
--- a/rmf.repos
+++ b/rmf.repos
@@ -67,7 +67,3 @@ repositories:
     type: git
     url: https://github.com/open-rmf/pybind11_json_vendor.git
     version: main
-  thirdparty/ros_ign:
-    type: git
-    url: https://github.com/ignitionrobotics/ros_ign.git
-    version: ros2


### PR DESCRIPTION
Signed-off-by: Aaron Chong <aaronchongth@gmail.com>

## New feature implementation

### Implemented feature

<!-- Briefly describe the feature being implemented.
If there is a feature request issue for the feature, link to that feature.
If there is not a feature request issue for the feature, create one first and fill out all the required information there, then link to that issue from this new feature pull request. -->

Removed buiding `ros_ign` packages from source, since the last release of 0.233.4 is out, https://github.com/ignitionrobotics/ros_ign/blob/galactic/ros_ign_bridge/CHANGELOG.rst.

Related to https://github.com/open-rmf/rmf/pull/144