### PR TITLE
Adding note regarding uninstalling binaries before source build

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ rosdep install --from-paths src --ignore-src --rosdistro galactic -y
 
 ### Compiling Instructions
 
-On `Ubuntu 20.04`:
+> NOTE: Due to newer changes in the source build, there might be conflicts and compilation errors with older header files installed by the binaries. Please remove the binary installations before building from source, using `sudo apt remove ros-galactic-rmf*`.
+
+Compiling on `Ubuntu 20.04`:
 
 ```bash
 cd ~/rmf_ws


### PR DESCRIPTION
Signed-off-by: Aaron Chong <aaronchongth@gmail.com>

<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Documentation

Added note to mention that binary installations should be removed before source builds to prevent conflicts and compilation errors with older headers installed.