### PR TITLE
Updated README for Humble installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ Setup a new ROS 2 workspace and pull in the demo repositories using `vcs`,
 ```bash
 mkdir -p ~/rmf_ws/src
 cd ~/rmf_ws
-wget https://raw.githubusercontent.com/open-rmf/rmf/main/rmf.repos
+wget https://raw.githubusercontent.com/open-rmf/rmf/humble-image/rmf.repos
 vcs import src < rmf.repos
-wget https://raw.githubusercontent.com/open-rmf/rmf/main/rmf-simulation.repos
+wget https://raw.githubusercontent.com/open-rmf/rmf/humble-image/rmf-simulation.repos
 vcs import src < rmf-simulation.repos
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ wget https://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
 
 ## Binary install
 
+> NOTE: Given that certain RMF binary packages for Humble are not released yet and are still work-in-progress, it is highly recommended to build from source.
+
 Latest OpenRMF binary packages are available for Ubuntu Jammy 22.04 for the `Humble` and `Rolling` releases of ROS 2. Older releases are also available on Ubuntu Focal 20.04 for `Foxy` and `Galactic`. Most OpenRMF packages have the prefix `rmf` on their name, therefore, you can find them by them by searching for the pattern `ros-<ro2distro>-rmf`, e.g., for galatic it would be:
 
 ```bash


### PR DESCRIPTION
Certain RMF binary packages for Humble are not released yet and are only available in source as of now.
This PR updates the README by adding a note to build from source. Also, changed the branch names being used to source the github repos. 


