### PR TITLE
Update galactic branch

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build_and_test:
     name: Nightly build and test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: rostooling/setup-ros-docker:ubuntu-focal-latest
     steps:
@@ -18,6 +18,8 @@ jobs:
           required-ros-distributions: galactic
       - name: install_clang
         run: sudo apt update && sudo apt install -y clang clang-tools lld
+      - name: fix cryptography==2.8 # https://github.com/open-rmf/rmf/pull/202#pullrequestreview-1100045417
+        run: pip3 install cryptography==2.8
       - uses: actions/checkout@v2
       - name: build_and_test
         uses: ros-tooling/action-ros-ci@v0.2

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -41,9 +41,6 @@ jobs:
             rmf_visualization_fleet_states
             rmf_visualization_rviz2_plugins
             rmf_visualization_schedule
-            rmf_building_sim_common
-            rmf_building_sim_gazebo_plugins
-            rmf_building_sim_ignition_plugins
             rmf_robot_sim_common
             rmf_robot_sim_gazebo_plugins
             rmf_robot_sim_ignition_plugins

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -13,7 +13,7 @@ jobs:
       image: rostooling/setup-ros-docker:ubuntu-focal-latest
     steps:
       - name: deps
-        uses: ros-tooling/setup-ros@v0.3
+        uses: ros-tooling/setup-ros@v0.4
         with:
           required-ros-distributions: galactic
       - name: install_clang

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,5 +1,5 @@
 name: nightly
-on: 
+on:
   push:
   pull_request:
   schedule:
@@ -9,16 +9,22 @@ jobs:
   build_and_test:
     name: Nightly build and test
     runs-on: ubuntu-20.04
+    container:
+      image: rostooling/setup-ros-docker:ubuntu-focal-latest
     steps:
       - name: deps
-        uses: ros-tooling/setup-ros@v0.2
+        uses: ros-tooling/setup-ros@v0.3
         with:
           required-ros-distributions: galactic
+      - name: install_clang
+        run: sudo apt update && sudo apt install -y clang clang-tools lld
       - uses: actions/checkout@v2
       - name: build_and_test
         uses: ros-tooling/action-ros-ci@v0.2
         env:
           QT_QPA_PLATFORM: offscreen
+          CC: clang
+          CXX: clang++
         with:
           target-ros2-distro: galactic
           # build all packages listed in the meta package
@@ -59,7 +65,7 @@ jobs:
           colcon-defaults: |
             {
               "build": {
-                "mixin": ["coverage-gcc"]
+                "mixin": ["coverage-gcc", "lld"]
               }
             }
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -33,8 +33,7 @@ jobs:
             rmf_traffic
             rmf_task
             rmf_battery
-            rmf_fleet_adapter
-            # rmf_fleet_adapter_python Tests need to be updated
+            rmf_fleet_adapter 
             rmf_task_ros2
             rmf_traffic_ros2
             rmf_visualization

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -43,6 +43,9 @@ jobs:
             rmf_visualization_fleet_states
             rmf_visualization_rviz2_plugins
             rmf_visualization_schedule
+            rmf_building_sim_common
+            rmf_building_sim_gazebo_plugins
+            rmf_building_sim_ignition_plugins
             rmf_robot_sim_common
             rmf_robot_sim_gazebo_plugins
             rmf_robot_sim_ignition_plugins

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -34,7 +34,7 @@ jobs:
             rmf_task
             rmf_battery
             rmf_fleet_adapter
-            rmf_fleet_adapter_python
+            # rmf_fleet_adapter_python Tests need to be updated
             rmf_task_ros2
             rmf_traffic_ros2
             rmf_visualization

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
     qt5-default \
     wget \
     python3-pip \
-  && pip3 install flask-socketio \
+  && pip3 install flask-socketio fastapi uvicorn \
   && rm -rf /var/lib/apt/lists/*
 
 # setup keys

--- a/README.md
+++ b/README.md
@@ -8,42 +8,18 @@
 The OpenRMF platform for multi-fleet robot management.
 
 ---
-## Install ROS 2 Galactic
 
-First, please follow the installation instructions for ROS 2 Galactic.
-If you are on an Ubuntu 20.04 LTS machine (as recommended), [here is the binary install page for ROS 2 Galactic on Ubuntu 20.04](https://docs.ros.org/en/galactic/Installation/Ubuntu-Install-Debians.html).
+For specific rmf versions follow the instructions given below:
 
-## Setup Gazebo repositories
+## Installation Instructions
 
-Setup your computer to accept Gazebo packages from packages.osrfoundation.org.
+These are the current Open-RMF binary releases available:
 
-```bash
-sudo apt update
-sudo apt install -y wget
-sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
-wget https://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
-```
-
-## Binary install
-
-OpenRMF binary packages are available for Ubuntu Focal 20.04 for the `Foxy`, `Galactic` and `Rolling` releases of ROS 2. Most OpenRMF packages have the prefix `rmf` on their name, therefore, you can find them by them by searching for the pattern `ros-<ro2distro>-rmf`, e.g., for galatic it would be:
-
-```bash
-apt-cache search ros-galactic-rmf
-```
-
-### RMF Demos
-
-A good way to install the `rmf` set of packages in one go is to install the one of the main [RMF Demos](https://github.com/open-rmf/rmf_demos) packages. This will pull all the rest of the OpenRMF packages as a dependency. The core of RMF demos is contained on the `rmf_demos` package. However, if you want to install it with simulation support, you should install the `rmf_demos_gz` or `rmf_demos_ign` package which come with gazebo or ignition support respectively. As an example, to install the ROS 2 Galactic release with gazebo support package, you would run:
-
-```bash
-sudo apt install ros-galactic-rmf-demos-gz
-```
+| RMF Version | Installation Instructions                                                        | Supported distros                                   | Supported ROS2 versions |
+| ----------- | -------------------------------------------------------------------------------- | --------------------------------------------------- | ----------------------- |
+| 21.09       |  [Installation instructions](https://github.com/open-rmf/rmf/tree/release/21.09) | Ubuntu 20.04, Ubuntu 21.09, RHEL 8 (deployment only) | Foxy, Galactic           |
 
 ## Building from sources
-
-If you want to get the latest developments you might want to install from sources and compile OpenRMF yourself.
-
 
 ### Additional Dependencies
 
@@ -69,6 +45,7 @@ rosdep update
 ```
 
 ### Download the source code
+
 Setup a new ROS 2 workspace and pull in the demo repositories using `vcs`,
 
 ```bash
@@ -79,7 +56,13 @@ vcs import src < rmf.repos
 ```
 
 Ensure all ROS 2 prerequisites are fulfilled,
-```
+
+you can subsutitute your distro name for `<your ros distro>`
+
+Example:
+for `galactic`
+
+```bash
 cd ~/rmf_ws
 rosdep install --from-paths src --ignore-src --rosdistro galactic -y
 ```
@@ -92,17 +75,12 @@ Compiling on `Ubuntu 20.04`:
 
 ```bash
 cd ~/rmf_ws
-source /opt/ros/galactic/setup.bash
+source /opt/ros/<your ros distro>/setup.bash
 colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release
 ```
 
 > NOTE: The first time the build occurs, many simulation models will be downloaded from Ignition Fuel to populate the scene when the simulation is run.
-As a result, the first build can take a very long time depending on the server load and your Internet connection (for example, 60 minutes).
-
-## Run RMF Demos
-
-Demonstrations of OpenRMF are shown in [rmf_demos](https://github.com/open-rmf/rmf_demos/).
-
+> As a result, the first build can take a very long time depending on the server load and your Internet connection (for example, 60 minutes).
 ### Docker Containers
 Alternatively, you can run RMF Demos by using [docker](https://docs.docker.com/engine/install/ubuntu/).
 
@@ -122,6 +100,10 @@ docker run -it --network host rmf:latest bash -c "export ROS_DOMAIN_ID=9; ros2 l
 This will run `rmf_demos` in headless mode. Open [this link](https://open-rmf.github.io/rmf-panel-js/) with a browser to start a task.
 
 (Experimental) User can also run `rmf_demos` in “non-headless” graphical form, via [rocker](https://github.com/osrf/rocker).
+
+## Run RMF Demos
+
+Demonstrations of OpenRMF are shown in [rmf_demos](https://github.com/open-rmf/rmf_demos/).
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ sudo apt update && sudo apt install \
   git cmake python3-vcstool curl \
   qt5-default \
   -y
-python3 -m pip install flask-socketio
+python3 -m pip install flask-socketio fastapi uvicorn
 sudo apt-get install python3-colcon*
 ```
 

--- a/rmf.repos
+++ b/rmf.repos
@@ -71,3 +71,4 @@ repositories:
     type: git
     url: https://github.com/ignitionrobotics/ros_ign.git
     version: galactic
+    

--- a/rmf.repos
+++ b/rmf.repos
@@ -2,59 +2,59 @@ repositories:
   rmf/rmf_battery:
     type: git
     url: https://github.com/open-rmf/rmf_battery.git
-    version: main
+    version: galactic-devel
   rmf/rmf_internal_msgs:
     type: git
     url: https://github.com/open-rmf/rmf_internal_msgs.git
-    version: main
+    version: galactic-devel
   rmf/rmf_api_msgs:
     type: git
     url: https://github.com/open-rmf/rmf_api_msgs.git
-    version: main
+    version: galactic-devel
   rmf/rmf_ros2:
     type: git
     url: https://github.com/open-rmf/rmf_ros2.git
-    version: main
+    version: galactic-devel
   rmf/rmf_task:
     type: git
     url: https://github.com/open-rmf/rmf_task.git
-    version: main
+    version: galactic-devel
   rmf/rmf_traffic:
     type: git
     url: https://github.com/open-rmf/rmf_traffic.git
-    version: main
+    version: galactic-devel
   rmf/rmf_utils:
     type: git
     url: https://github.com/open-rmf/rmf_utils.git
-    version: main
+    version: galactic-devel
   rmf/ament_cmake_catch2:
     type: git
     url: https://github.com/open-rmf/ament_cmake_catch2.git
-    version: main
+    version: galactic-devel
   rmf/rmf_visualization:
     type: git
     url: https://github.com/open-rmf/rmf_visualization.git
-    version: main
+    version: galactic-devel
   rmf/rmf_visualization_msgs:
     type: git
     url: https://github.com/open-rmf/rmf_visualization_msgs.git
-    version: main
+    version: galactic-devel
   rmf/rmf_building_map_msgs:
     type: git
     url: https://github.com/open-rmf/rmf_building_map_msgs.git
-    version: main
+    version: galactic-devel
   rmf/rmf_simulation:
     type: git
     url: https://github.com/open-rmf/rmf_simulation.git
-    version: main
+    version: galactic-devel
   rmf/rmf_traffic_editor:
     type: git
     url: https://github.com/open-rmf/rmf_traffic_editor.git
-    version: main
+    version: galactic-devel
   demonstrations/rmf_demos:
     type: git
     url: https://github.com/open-rmf/rmf_demos.git
-    version: main
+    version: galactic-devel
   thirdparty/menge_vendor:
     type: git
     url: https://github.com/open-rmf/menge_vendor.git
@@ -71,4 +71,3 @@ repositories:
     type: git
     url: https://github.com/ignitionrobotics/ros_ign.git
     version: galactic
-    


### PR DESCRIPTION
This PR 
1. Merges in latest `main` into `galactic`
2. Updates the `rmf.repos` file to checkout `galactic-devel` branches of the Open-RMF repos which has recently been created.

Moving forward `main` will be supported on `humble`. See https://github.com/open-rmf/rmf/pull/165
We can add instructions to that PR to inform users to use the `galactic` version of the `rmf.repos` file if the would like to build `Open-RMF` from source + `galactic`