### PR TITLE
Fix missing dependency of rmf_api_msgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Install all non-ROS dependencies of OpenRMF packages,
 sudo apt update && sudo apt install \
   git cmake python3-vcstool curl \
   -y
-python3 -m pip install flask-socketio fastapi uvicorn
+python3 -m pip install flask-socketio fastapi uvicorn datamodel_code_generator
 sudo apt-get install python3-colcon*
 ```
 


### PR DESCRIPTION
<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix

### Fixed bug

<!-- Briefly describe the bug being fixed.
If there is a bug report issue for the bug, link to that issue.
If there is not a bug report issue for the bug, create one first and fill out all the required information there, then link to that issue from this bug fix pull request. -->
https://github.com/open-rmf/rmf/issues/249 

### Fix applied

<!-- Describe in detail the approach taken, tools used, etc. to identify the cause of the bug and what was done to fix it. -->
This dependency seems not to be possible to install via rosdep - I searched here: https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/python.yaml
So it can't be added to package.xml of rmf_api_msgs. It has to be added probably to the installation tutorial. 
