### PR TITLE
Updates Clang and LLD install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Compiling on `Ubuntu 22.04`:
 
 ```bash
 sudo apt update
-sudo apt install clang clang-tools lld libstdc++-12-dev
+sudo apt install clang clang-tools lldb lld libstdc++-12-dev
 ```
 
 **NOTE: We strongly recommend compiling Open-RMF packages with `clang` as compiler and `lld` as linker.**

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Compiling on `Ubuntu 22.04`:
 
 ```bash
 sudo apt update
-sudo apt install clang lldb lld
+sudo apt install clang clang-tools lld libstdc++-12-dev
 ```
 
 **NOTE: We strongly recommend compiling Open-RMF packages with `clang` as compiler and `lld` as linker.**


### PR DESCRIPTION
Building with `clang` and `lld` without installing `libstdc++-12-dev` leads to linker errors when trying to compile trivial C++ code on ubuntu 22.04. This PR updates the instructions to have users install the correct version of `libstdc++-12-dev`. Thanks @Yadunund for the suggestion.

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>
