### PR TITLE
pip apt package should be installed before using.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Install all non-ROS dependencies of OpenRMF packages,
 
 ```bash
 sudo apt update && sudo apt install \
-  git cmake python3-vcstool curl \
+  git cmake python3-vcstool curl pip \
   -y
 python3 -m pip install flask-socketio fastapi uvicorn datamodel_code_generator
 sudo apt-get install python3-colcon*


### PR DESCRIPTION
## Bug fix

### Fixed bug

Just a doc fix.

### Fix applied

to avoid the following error.

```bash
root@tomoyafujita:/# python3 -m pip install flask-socketio fastapi uvicorn datamodel_code_generator
/usr/bin/python3: No module named pip
```