### PR TITLE
Add workflow to mirror main to rolling

### DIFF
--- a/.github/workflows/mirror-main-to-rolling.yaml
+++ b/.github/workflows/mirror-main-to-rolling.yaml
@@ -1,0 +1,13 @@
+name: Mirror main to rolling
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  mirror-to-rolling:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: zofrex/mirror-branch@v1
+      with:
+        target-branch: rolling


### PR DESCRIPTION
There is a `rolling` distro branch in this repo but since we distribute packages to `rolling` from `main` of all repos, we will simply have the `rolling` branch here mirror the `main` branch. This PR adds a github action that will ensure rolling is just a mirror of main.