### PR TITLE
Removing datamodel_code_generator from main installation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,8 @@ sudo apt update && sudo apt install \
 sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
 wget https://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
 
+# These pip packages are only used by rmf_demos which are not released as binaries
 python3 -m pip install flask-socketio fastapi uvicorn
-
-python3 -m pip install datamodel_code_generator==0.11.19
 ```
 
 `rosdep` helps install dependencies for ROS packages across various distros and will be installed along with `ros-dev-tools`.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ sudo apt update && sudo apt install \
 sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
 wget https://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
 
-python3 -m pip install flask-socketio fastapi uvicorn datamodel_code_generator
+python3 -m pip install flask-socketio fastapi uvicorn
+
+python3 -m pip install datamodel_code_generator==0.11.19
 ```
 
 `rosdep` helps install dependencies for ROS packages across various distros and will be installed along with `ros-dev-tools`.


### PR DESCRIPTION
## Bug fix

### Fixed bug

<!-- Briefly describe the bug being fixed.
If there is a bug report issue for the bug, link to that issue.
If there is not a bug report issue for the bug, create one first and fill out all the required information there, then link to that issue from this bug fix pull request. -->

Fixes https://github.com/open-rmf/rmf/issues/372.

### Fix applied

* remove `datamodel_code_generator` from installation step as it is not released by binaries, and only emits a warning even when building `rmf_api_msgs` from source, not crashing the build, as per https://github.com/open-rmf/rmf/issues/249
* `datamodel_code_generator` will only be used if a user is trying to create their own `api-server` via the schemas from `rmf_api_msgs`, otherwise it is not used at all
* any mentions of `datamodel_code_generator` will only be in `rmf_api_msgs`

### Verify warning instead of crash

Using `podman`,

```bash
podman run -it docker.io/library/ros:humble-ros-base-jammy

# inside the image
mkdir -p ~/ws/src
cd ~/ws/src
git clone https://github.com/open-rmf/rmf_api_msgs
cd ~/ws
rosdep install --from-paths src --ignore-src --rosdistro humble -y
source /opt/ros/humble/setup.bash
colcon build
# only emits warning, still builds fine
```