### PR TITLE
Alphabetize entries in repos file

### DIFF
--- a/rmf.repos
+++ b/rmf.repos
@@ -1,19 +1,35 @@
 repositories:
-  rmf/rmf_battery:
+  demonstrations/rmf_demos:
     type: git
-    url: https://github.com/open-rmf/rmf_battery.git
+    url: https://github.com/open-rmf/rmf_demos.git
     version: main
-  rmf/rmf_internal_msgs:
+  rmf/ament_cmake_catch2:
     type: git
-    url: https://github.com/open-rmf/rmf_internal_msgs.git
+    url: https://github.com/open-rmf/ament_cmake_catch2.git
     version: main
   rmf/rmf_api_msgs:
     type: git
     url: https://github.com/open-rmf/rmf_api_msgs.git
     version: main
+  rmf/rmf_battery:
+    type: git
+    url: https://github.com/open-rmf/rmf_battery.git
+    version: main
+  rmf/rmf_building_map_msgs:
+    type: git
+    url: https://github.com/open-rmf/rmf_building_map_msgs.git
+    version: main
+  rmf/rmf_internal_msgs:
+    type: git
+    url: https://github.com/open-rmf/rmf_internal_msgs.git
+    version: main
   rmf/rmf_ros2:
     type: git
     url: https://github.com/open-rmf/rmf_ros2.git
+    version: main
+  rmf/rmf_simulation:
+    type: git
+    url: https://github.com/open-rmf/rmf_simulation.git
     version: main
   rmf/rmf_task:
     type: git
@@ -23,13 +39,13 @@ repositories:
     type: git
     url: https://github.com/open-rmf/rmf_traffic.git
     version: main
+  rmf/rmf_traffic_editor:
+    type: git
+    url: https://github.com/open-rmf/rmf_traffic_editor.git
+    version: main
   rmf/rmf_utils:
     type: git
     url: https://github.com/open-rmf/rmf_utils.git
-    version: main
-  rmf/ament_cmake_catch2:
-    type: git
-    url: https://github.com/open-rmf/ament_cmake_catch2.git
     version: main
   rmf/rmf_visualization:
     type: git
@@ -38,22 +54,6 @@ repositories:
   rmf/rmf_visualization_msgs:
     type: git
     url: https://github.com/open-rmf/rmf_visualization_msgs.git
-    version: main
-  rmf/rmf_building_map_msgs:
-    type: git
-    url: https://github.com/open-rmf/rmf_building_map_msgs.git
-    version: main
-  rmf/rmf_simulation:
-    type: git
-    url: https://github.com/open-rmf/rmf_simulation.git
-    version: main
-  rmf/rmf_traffic_editor:
-    type: git
-    url: https://github.com/open-rmf/rmf_traffic_editor.git
-    version: main
-  demonstrations/rmf_demos:
-    type: git
-    url: https://github.com/open-rmf/rmf_demos.git
     version: main
   thirdparty/menge_vendor:
     type: git


### PR DESCRIPTION
Quality of life improvement to make version bump diffs easier to manage as `vcs export --exact-with-tags` will export the repos in a alphabetical order. This would avoid doing this for every `distro` branch we create when a new ROS 2 version is released.