### PR TITLE
Add `rosdep update`  before `rosdep install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,11 +110,12 @@ wget https://raw.githubusercontent.com/open-rmf/rmf/main/rmf.repos
 vcs import src < rmf.repos
 ```
 
-Install dependencies via `rosdep`.
+Update your rosdep definitions and install dependencies via `rosdep`.
 Replace `humble` with ROS 2 distro of your choice.
 
 ```bash
 cd ~/rmf_ws
+rosdep update
 rosdep install --from-paths src --ignore-src --rosdistro humble -y
 ```
 

--- a/README.md
+++ b/README.md
@@ -111,13 +111,12 @@ vcs import src < rmf.repos
 ```
 
 Update your rosdep definitions and install dependencies via `rosdep`.
-Replace `$ROS_DISTRO` with ROS 2 distro of your choice.
 
 ```bash
 cd ~/rmf_ws
 sudo apt update
 rosdep update
-# source your preferred ROS distribution. Eg: `source /opt/ros/rolling/setup.bash`
+source /opt/ros/humble/setup.bash # replace humble with preferred ROS 2 distro.
 rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO -y
 ```
 
@@ -132,8 +131,6 @@ Compile the workspace after sourcing the ROS 2 distro of choice.
 
 ```bash
 cd ~/rmf_ws
-source /opt/ros/humble/setup.bash # replace humble with ROS 2 distro of choice.
-
 export CXX=clang++
 export CC=clang
 colcon build --mixin release lld

--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ Replace `humble` with ROS 2 distro of your choice.
 ```bash
 cd ~/rmf_ws
 rosdep update
-rosdep install --from-paths src --ignore-src --rosdistro humble -y
+# source your preferred ROS distribution. Eg: `source /opt/ros/rolling/setup.bash`
+rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO -y
 ```
 
 **NOTE: We strongly recommend compiling Open-RMF packages with `clang` as compiler and `lld` as linker.**

--- a/README.md
+++ b/README.md
@@ -111,10 +111,11 @@ vcs import src < rmf.repos
 ```
 
 Update your rosdep definitions and install dependencies via `rosdep`.
-Replace `humble` with ROS 2 distro of your choice.
+Replace `$ROS_DISTRO` with ROS 2 distro of your choice.
 
 ```bash
 cd ~/rmf_ws
+sudo apt update
 rosdep update
 # source your preferred ROS distribution. Eg: `source /opt/ros/rolling/setup.bash`
 rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO -y


### PR DESCRIPTION
I know we ask the user to run `rosdep update` when they install `ros-dev-tools` for the first time. However, it probably is a good idea to `rosdep update` before running `rosdep install`.
