### PR TITLE
Use a newer version of upload-artifact

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -67,7 +67,7 @@ jobs:
             }
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
       - name: Upload build logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: colcon-build-logs
           path: ${{ steps.action_ros_ci_step.outputs.ros-workspace-directory-name }}/log


### PR DESCRIPTION
The nightly build has been failing for a while because we've been stuck on a deprecated version of `actions/upload-artifact`. This PR brings it to the same version that we're using in the reusable workflow template.