### PR TITLE
Add a workflow to add new tickets to the project

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,16 @@
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+name: Ticket opened
+jobs:
+  assign:
+    name: Add ticket to inbox
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add ticket to inbox
+        uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/open-rmf/projects/10
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
Inspired by the [Gazebo workflow](https://github.com/gazebosim/gz-sim/blob/gz-sim9/.github/workflows/triage.yml). I believe we need to create a secret for this following [this guide](https://github.com/actions/add-to-project?tab=readme-ov-file#creating-a-pat-and-adding-it-to-your-repository)