### PR TITLE
Remove pybind11_json_vendor from repos file

### DIFF
--- a/rmf.repos
+++ b/rmf.repos
@@ -63,7 +63,3 @@ repositories:
     type: git
     url: https://github.com/open-rmf/nlohmann_json_schema_validator_vendor.git
     version: main
-  thirdparty/pybind11_json_vendor:
-    type: git
-    url: https://github.com/open-rmf/pybind11_json_vendor.git
-    version: main


### PR DESCRIPTION
This PR follows up on https://github.com/open-rmf/rmf_ros2/pull/444 by removing the `pybind11_json_vendor` package which is no longer needed.