### PR TITLE
Restore pybind11_json_vendor to repos

### DIFF
--- a/.github/humble/rmf-humble-latest.repos
+++ b/.github/humble/rmf-humble-latest.repos
@@ -63,3 +63,7 @@ repositories:
     type: git
     url: https://github.com/open-rmf/nlohmann_json_schema_validator_vendor.git
     version: main
+  thirdparty/pybind11_json_vendor:
+    type: git
+    url: https://github.com/open-rmf/pybind11_json_vendor
+    version: main

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,7 @@ on:
   schedule:
     - cron: '1 8 * * *'
 jobs:
-  build-humble-docker-image:
+  build-backported-docker-image:
     name: Push Docker image for ROS 2 Humble to GitHub Packages
     runs-on: ubuntu-latest
     strategy:
@@ -28,14 +28,14 @@ jobs:
           build-args: |
             ROS_DISTRO=${{ matrix.ros_distribution }}
           tags: ghcr.io/${{ github.repository }}/rmf_demos:${{ matrix.ros_distribution }}-rmf-latest
-          context: .github/humble
+          context: .github/${{ matrix.ros_distribution }}
   build-docker-images:
     name: Push Docker image to GitHub Packages
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        ros_distribution: ["jazzy", "kilted", "rolling"]
+        ros_distribution: ["jazzy", "lyrical", "rolling"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ros_distribution: ["jazzy", "lyrical", "rolling"]
+        ros_distribution: ["jazzy", "kilted", "lyrical", "rolling"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG ROS_DISTRO=jazzy
+ARG ROS_DISTRO=lyrical
 ARG BASE_IMAGE=ros:${ROS_DISTRO}-ros-base
 FROM $BASE_IMAGE
 

--- a/rmf.repos
+++ b/rmf.repos
@@ -63,3 +63,7 @@ repositories:
     type: git
     url: https://github.com/open-rmf/nlohmann_json_schema_validator_vendor.git
     version: main
+  thirdparty/pybind11_json_vendor:
+    type: git
+    url: https://github.com/open-rmf/pybind11_json_vendor
+    version: main


### PR DESCRIPTION
Because of the packaging issue described in https://github.com/open-rmf/pybind11_json_vendor/pull/18 we need to go back to vendoring the `pybind11_json` package. That means we should also bring it back to this repos file.